### PR TITLE
Open LogFile for writing

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -327,10 +327,7 @@ LogFile.prototype = {
         this.open();
     },
     open: function() {
-        this.fd = fs.openSync(
-            this.filename,
-            process.O_WRONLY|process.O_CREAT|process.O_TRUNC,
-            process.S_IRWXU|process.S_IRWXG|process.S_IROTH);
+        this.fd = fs.openSync(this.filename, "w");
     },
     close: function() {
         fs.closeSync(this.fd);


### PR DESCRIPTION
The node.js documents refer to '2 open' but should refer to '2 fopen'. Later versions of node fail to open the log file if you pass the masked bit flag. Instead, pass "w" as in this patch and the node.js documentation.
